### PR TITLE
Add cleanup methods in HEU and HUU pool generation



### DIFF
--- a/pre_flourish/helper_classes/heu_pool_generation.py
+++ b/pre_flourish/helper_classes/heu_pool_generation.py
@@ -40,6 +40,7 @@ class HEUPoolGeneration(MatchHelper):
         participants = self.child_clinical_measurements_cls.objects.filter(
             id__in=latest_clinical_measurements_ids,
         ).select_related('child_visit')
+        self.heu_obj_clean_up()
         return self.get_heu_bmi_age_data(participants)
 
     def child_consent(self, caregiver_child_consent_cls, participant):
@@ -81,6 +82,9 @@ class HEUPoolGeneration(MatchHelper):
                 subject_data[bmi_group][age_range][gender].append(subj_id)
 
         self.prepare_create_pool('heu', bmi_age_data, subject_data)
+
+    def heu_obj_clean_up(self):
+        self.matrix_pool_cls.objects.filter(pool='heu').delete()
 
     @property
     def exposed_participants(self):

--- a/pre_flourish/helper_classes/huu_pool_generation.py
+++ b/pre_flourish/helper_classes/huu_pool_generation.py
@@ -33,6 +33,7 @@ class HUUPoolGeneration(MatchHelper):
                                                                        flat=True)
         participants = self.get_valid_participants(latest_huu_pre_enrollment_ids)
         bmi_age_data, subject_data = self.get_huu_bmi_age_data(participants)
+        self.huu_obj_clean_up()
         self.prepare_create_pool('huu', bmi_age_data, subject_data)
 
     def get_valid_participants(self, latest_huu_pre_enrollment_ids):
@@ -44,6 +45,9 @@ class HUUPoolGeneration(MatchHelper):
             child_weight_kg__gt=0,
         )
         return participants
+
+    def huu_obj_clean_up(self):
+        self.matrix_pool_cls.objects.filter(pool='huu').delete()
 
     def get_huu_bmi_age_data(self, participants, active_match=False):
         if not participants:


### PR DESCRIPTION
Added methods `heu_obj_clean_up` and `huu_obj_clean_up` in the respective HEU and HUU pool generation classes to delete objects in the matrix pool. These cleanup methods ensure each matrix pool is cleared before creating a new one, reducing potential duplication or mix-up of data.