### PR TITLE
(refactor): Update consent version handling in pre-flourish models

### DIFF
--- a/pre_flourish/apps.py
+++ b/pre_flourish/apps.py
@@ -14,11 +14,12 @@ class AppConfig(DjangoAppConfig):
     verbose_name = 'Pre Flourish'
     admin_site_name = 'pre_flourish_admin'
 
-    consent_version = 4
+    consent_version = 4.1
     child_consent_version = 4
 
     def ready(self):
-        pass
+        import pre_flourish.models.child.signals
+        import pre_flourish.models.caregiver.signals
 
 
 if settings.APP_NAME == 'pre_flourish':

--- a/pre_flourish/choices.py
+++ b/pre_flourish/choices.py
@@ -251,4 +251,5 @@ CHILD_CONSENT_VERSION = (
 CONSENT_VERSION = (
     ('1', 'Consent version 1'),
     ('4', 'Consent version 4'),
+    ('4.1', 'Consent version 4.1'),
 )

--- a/pre_flourish/consents.py
+++ b/pre_flourish/consents.py
@@ -25,6 +25,16 @@ v4 = Consent(
     age_max=110,
     gender=[MALE, FEMALE])
 
+v4_1 = Consent(
+    'pre_flourish.preflourishconsent',
+    version='4.1',
+    start=edc_protocol.study_open_datetime,
+    end=edc_protocol.study_close_datetime,
+    age_min=18,
+    age_is_adult=18,
+    age_max=110,
+    gender=[MALE, FEMALE])
+
 child_consent_v1 = Consent(
     'pre_flourish.preflourishcaregiverchildconsent',
     version='1',
@@ -65,5 +75,6 @@ site_consents.register(v1)
 site_consents.register(child_consent_v1)
 site_consents.register(child_consent_dummy_v1)
 site_consents.register(v4)
+site_consents.register(v4_1)
 site_consents.register(child_consent_v4)
 site_consents.register(child_consent_dummy_v4)

--- a/pre_flourish/model_wrappers/caregiver/consent_model_wrapper_mixin.py
+++ b/pre_flourish/model_wrappers/caregiver/consent_model_wrapper_mixin.py
@@ -42,14 +42,14 @@ class ConsentModelWrapperMixin:
     def consent_version_cls(self):
         return django_apps.get_model('pre_flourish.pfconsentversion')
 
-    def get_consent_version(self, default_version):
+    def get_consent_version(self, default_version, child=None):
         try:
             consent_version_obj = self.consent_version_cls.objects.get(
                 screening_identifier=self.screening_identifier)
         except self.consent_version_cls.DoesNotExist:
             return default_version
         else:
-            return consent_version_obj.version
+            return consent_version_obj.version if not child else consent_version_obj.child_version
 
     @property
     def consent_version(self):
@@ -57,7 +57,8 @@ class ConsentModelWrapperMixin:
 
     @property
     def child_consent_version(self):
-        return self.get_consent_version(pre_flourish_config.child_consent_version)
+        return self.get_consent_version(pre_flourish_config.child_consent_version,
+                                        child=True)
 
     @property
     def consent_model_obj(self):

--- a/pre_flourish/model_wrappers/caregiver/consent_model_wrapper_mixin.py
+++ b/pre_flourish/model_wrappers/caregiver/consent_model_wrapper_mixin.py
@@ -1,6 +1,6 @@
 from django.apps import apps as django_apps
 from django.core.exceptions import ObjectDoesNotExist
-from edc_base.utils import get_utcnow, get_uuid
+from edc_base.utils import get_uuid
 
 from edc_consent.site_consents import site_consents
 
@@ -42,31 +42,22 @@ class ConsentModelWrapperMixin:
     def consent_version_cls(self):
         return django_apps.get_model('pre_flourish.pfconsentversion')
 
-    @property
-    def consent_version(self):
-        version = None
-
+    def get_consent_version(self, default_version):
         try:
             consent_version_obj = self.consent_version_cls.objects.get(
                 screening_identifier=self.screening_identifier)
         except self.consent_version_cls.DoesNotExist:
-            version = pre_flourish_config.consent_version
+            return default_version
         else:
-            version = consent_version_obj.version
-        return version
+            return consent_version_obj.version
+
+    @property
+    def consent_version(self):
+        return self.get_consent_version(pre_flourish_config.consent_version)
 
     @property
     def child_consent_version(self):
-        version = None
-        try:
-            consent_version_obj = self.consent_version_cls.objects.get(
-                screening_identifier=self.screening_identifier)
-        except self.consent_version_cls.DoesNotExist:
-            pass
-        else:
-            version = consent_version_obj.child_version
-
-        return version if version else self.consent_version
+        return self.get_consent_version(pre_flourish_config.child_consent_version)
 
     @property
     def consent_model_obj(self):

--- a/pre_flourish/models/caregiver/__init__.py
+++ b/pre_flourish/models/caregiver/__init__.py
@@ -9,4 +9,3 @@ from .pre_flourish_log_entry import *
 from .pre_flourish_off_study import PreFlourishOffStudy
 from .pre_flourish_subject_screening import PreFlourishSubjectScreening
 from .hiv_rapid_test_counseling import PFHIVRapidTestCounseling
-from .signals import pre_flourish_consent_on_post_save

--- a/pre_flourish/models/caregiver/onschedule.py
+++ b/pre_flourish/models/caregiver/onschedule.py
@@ -50,8 +50,7 @@ class OnScheduleModelMixin(BaseOnScheduleModelMixin, BaseUuidModel):
         version = None
         try:
             consent_version_obj = self.consent_version_model.objects.get(
-                screening_identifier=self.screening_identifier,
-                version=str(pre_flourish_config.consent_version)
+                screening_identifier=self.screening_identifier
             )
         except self.consent_version_model.DoesNotExist:
             version = '1'

--- a/pre_flourish/models/caregiver/onschedule.py
+++ b/pre_flourish/models/caregiver/onschedule.py
@@ -1,13 +1,14 @@
+from django.apps import apps as django_apps
 from django.db import models
 from edc_base.model_managers import HistoricalRecords
 from edc_base.model_mixins import BaseUuidModel
 from edc_base.sites import CurrentSiteManager
 from edc_identifier.managers import SubjectIdentifierManager
-
-from edc_visit_schedule.model_mixins import OnScheduleModelMixin as BaseOnScheduleModelMixin
-from django.apps import apps as django_apps
+from edc_visit_schedule.model_mixins import \
+    OnScheduleModelMixin as BaseOnScheduleModelMixin
 
 pre_flourish_config = django_apps.get_app_config('pre_flourish')
+
 
 class OnScheduleModelMixin(BaseOnScheduleModelMixin, BaseUuidModel):
     """A model used by the system. Auto-completed by enrollment model.
@@ -33,8 +34,39 @@ class OnScheduleModelMixin(BaseOnScheduleModelMixin, BaseUuidModel):
         pass
 
     def save(self, *args, **kwargs):
-        self.consent_version = str(pre_flourish_config.consent_version)
+        self.consent_version = self.get_version
         super().save(*args, **kwargs)
+
+    @property
+    def consent_version_model(self):
+        return django_apps.get_model('pre_flourish', 'PFConsentVersion')
+
+    @property
+    def subject_consent_model(self):
+        return django_apps.get_model('pre_flourish', 'PreFlourishConsent')
+
+    @property
+    def get_version(self):
+        version = None
+        try:
+            consent_version_obj = self.consent_version_model.objects.get(
+                screening_identifier=self.screening_identifier,
+                version=str(pre_flourish_config.consent_version)
+            )
+        except self.consent_version_model.DoesNotExist:
+            version = '1'
+        else:
+            version = consent_version_obj.version
+        return version
+
+    @property
+    def screening_identifier(self):
+        try:
+            return self.subject_consent_model.objects.filter(
+                subject_identifier=self.subject_identifier,
+            ).latest('consent_datetime').screening_identifier
+        except self.subject_consent_model.DoesNotExist:
+            pass
 
     class Meta:
         unique_together = ('subject_identifier', 'schedule_name')
@@ -42,10 +74,8 @@ class OnScheduleModelMixin(BaseOnScheduleModelMixin, BaseUuidModel):
 
 
 class OnSchedulePreFlourish(OnScheduleModelMixin):
-
     pass
 
 
 class OnScheduleChildPreFlourish(OnScheduleModelMixin):
-
     pass

--- a/pre_flourish/models/caregiver/pre_flourish_consent.py
+++ b/pre_flourish/models/caregiver/pre_flourish_consent.py
@@ -32,12 +32,11 @@ class SubjectConsentManager(SearchSlugManager, models.Manager):
 
 
 class PreFlourishConsent(
-        ConsentModelMixin, SiteModelMixin,
-        UpdatesOrCreatesRegistrationModelMixin,
-        NonUniqueSubjectIdentifierModelMixin, IdentityFieldsMixin,
-        ReviewFieldsMixin, PersonalFieldsMixin, CitizenFieldsMixin,
-        VulnerabilityFieldsMixin, SearchSlugModelMixin, BaseUuidModel):
-
+    ConsentModelMixin, SiteModelMixin,
+    UpdatesOrCreatesRegistrationModelMixin,
+    NonUniqueSubjectIdentifierModelMixin, IdentityFieldsMixin,
+    ReviewFieldsMixin, PersonalFieldsMixin, CitizenFieldsMixin,
+    VulnerabilityFieldsMixin, SearchSlugModelMixin, BaseUuidModel):
     """ A model completed by the user on the mother's consent. """
 
     subject_screening_model = 'flourish_caregiver.subjectscreening'
@@ -130,12 +129,12 @@ class PreFlourishConsent(
         consent_version_cls = django_apps.get_model(
             'pre_flourish.pfconsentversion')
 
-        if not self.version:
+        if self.version == '1' or self.version == '':
             try:
                 consent_version_obj = consent_version_cls.objects.get(
                     screening_identifier=self.screening_identifier)
             except consent_version_cls.DoesNotExist:
-                self.version = '1'
+                self.version = pre_flourish_config.consent_version
             else:
                 self.version = consent_version_obj.version
 

--- a/pre_flourish/models/caregiver/pre_flourish_consent.py
+++ b/pre_flourish/models/caregiver/pre_flourish_consent.py
@@ -135,7 +135,7 @@ class PreFlourishConsent(
                 consent_version_obj = consent_version_cls.objects.get(
                     screening_identifier=self.screening_identifier)
             except consent_version_cls.DoesNotExist:
-                self.version = str(pre_flourish_config.consent_version)
+                self.version = '1'
             else:
                 self.version = consent_version_obj.version
 

--- a/pre_flourish/models/caregiver/pre_flourish_consent.py
+++ b/pre_flourish/models/caregiver/pre_flourish_consent.py
@@ -129,12 +129,12 @@ class PreFlourishConsent(
         consent_version_cls = django_apps.get_model(
             'pre_flourish.pfconsentversion')
 
-        if self.version == '1' or self.version == '':
+        if not self.version:
             try:
                 consent_version_obj = consent_version_cls.objects.get(
                     screening_identifier=self.screening_identifier)
             except consent_version_cls.DoesNotExist:
-                self.version = pre_flourish_config.consent_version
+                self.version = str(pre_flourish_config.consent_version)
             else:
                 self.version = consent_version_obj.version
 

--- a/pre_flourish/models/caregiver/signals.py
+++ b/pre_flourish/models/caregiver/signals.py
@@ -60,6 +60,7 @@ def pre_flourish_consent_on_post_save(sender, instance, raw, created, **kwargs):
 
             update_locator(consent=instance, screening=caregiver_screening)
             update_worklist(caregiver_screening.study_maternal_identifier)
+            create_consent_version(instance, instance.version)
 
 
 @receiver(post_save, weak=False, sender=PreFlourishSubjectScreening,
@@ -69,7 +70,6 @@ def pre_flourish_screening_on_post_save(sender, instance, raw, created, **kwargs
     """
     if not raw and instance.is_eligible:
         update_locator(consent=None, screening=instance)
-    create_consent_version(instance, pre_flourish_config.consent_version)
 
 
 @receiver(post_save, weak=False, sender=PreFlourishChildAssent,
@@ -127,7 +127,7 @@ def put_on_schedule(instance, subject_identifier,
                 onschedule_obj.save()
 
 
-def create_consent_version(instance, version):
+def create_consent_version(instance, version, child_version=None):
     consent_version_cls = django_apps.get_model(
         'pre_flourish.pfconsentversion')
 
@@ -138,7 +138,7 @@ def create_consent_version(instance, version):
         consent_version = consent_version_cls(
             screening_identifier=instance.screening_identifier,
             version=version,
-            child_version=pre_flourish_config.child_consent_version,
+            child_version=child_version,
             user_created=instance.user_modified or instance.user_created,
             created=get_utcnow())
         consent_version.save()

--- a/pre_flourish/models/child/pre_flourish_child_assent.py
+++ b/pre_flourish/models/child/pre_flourish_child_assent.py
@@ -28,7 +28,6 @@ class PreFlourishChildAssent(SiteModelMixin, NonUniqueSubjectIdentifierFieldMixi
                              IdentityFieldsMixin, PersonalFieldsMixin, ReviewFieldsMixin,
                              VulnerabilityFieldsMixin, CitizenFieldsMixin,
                              VerificationFieldsMixin, BaseUuidModel):
-
     identity = IdentityField(
         verbose_name='Identity number',
         null=True,
@@ -51,7 +50,7 @@ class PreFlourishChildAssent(SiteModelMixin, NonUniqueSubjectIdentifierFieldMixi
         verbose_name=('Are you willing to continue the study when you reach 18'
                       ' years of age?'),
         choices=YES_NO,
-        )
+    )
 
     hiv_testing = models.CharField(
         max_length=3,
@@ -68,7 +67,8 @@ class PreFlourishChildAssent(SiteModelMixin, NonUniqueSubjectIdentifierFieldMixi
 
     specimen_consent = models.CharField(
         max_length=3,
-        verbose_name='Do you give us permission to use your blood samples for future studies?',
+        verbose_name='Do you give us permission to use your blood samples for future '
+                     'studies?',
         choices=YES_NO)
 
     consent_datetime = models.DateTimeField(
@@ -103,8 +103,8 @@ class PreFlourishChildAssent(SiteModelMixin, NonUniqueSubjectIdentifierFieldMixi
     @property
     def screening_identifier(self):
         try:
-            child_consent = self.pre_flourish_child_consent_cls.objects.get(
-                subject_identifier=self.subject_identifier)
+            child_consent = self.pre_flourish_child_consent_cls.objects.filter(
+                subject_identifier=self.subject_identifier).latest('consent_datetime')
         except self.pre_flourish_child_consent_cls.DoesNotExist:
             return None
         else:

--- a/pre_flourish/models/child/pre_flourish_child_consent.py
+++ b/pre_flourish/models/child/pre_flourish_child_consent.py
@@ -133,8 +133,8 @@ class PreFlourishCaregiverChildConsent(SiteModelMixin,
     def save(self, *args, **kwargs):
         self.child_age_at_enrollment = age(self.child_dob, get_utcnow()).years
 
-        self.version = self.child_consent_version or str(
-            pre_flourish_config.child_consent_version)
+        if not self.version:
+            self.version = self.child_consent_version
 
         if not self.subject_identifier:
             self.subject_identifier = PFInfantIdentifier(
@@ -206,7 +206,9 @@ class PreFlourishCaregiverChildConsent(SiteModelMixin,
         except consent_version_cls.DoesNotExist:
             return None
         else:
-            return consent_version_obj.child_version
+            return consent_version_obj.child_version if (
+                consent_version_obj.child_version) else (
+                pre_flourish_config.child_consent_version)
 
     @property
     def child_dataset(self):

--- a/pre_flourish/tests/test_reconsent.py
+++ b/pre_flourish/tests/test_reconsent.py
@@ -79,7 +79,7 @@ class Reconsent(TestCase):
         self.assertEqual(
             PFConsentVersion.objects.get(
                 screening_identifier=caregiver_screening.screening_identifier).version,
-            pre_flourish_subject_consent.version
+            str(pre_flourish_subject_consent.version)
         )
 
     @tag('ucvo')
@@ -136,7 +136,9 @@ class Reconsent(TestCase):
 
         pre_flourish_subject_consent = mommy.make_recipe(
             'pre_flourish.preflourishconsent',
-            screening_identifier=caregiver_screening.screening_identifier, )
+            screening_identifier=caregiver_screening.screening_identifier,
+            version=str(pre_flourish_config.consent_version)
+        )
 
         pre_flourish_subject_consent.save()
 
@@ -173,12 +175,14 @@ class Reconsent(TestCase):
         self.assertEqual(version_4.version, '4')
         self.assertEqual(child_version_4.version, '4')
 
+    @tag('rl')
     def test_reconsent_latest(self):
         consent_version_obj = PFConsentVersion.objects.get(
             screening_identifier=self.caregiver_screening.screening_identifier)
         consent_version_obj.version = '4.1'
         consent_version_obj.child_version = '4'
         consent_version_obj.save()
+
         version_4 = mommy.make_recipe(
             'pre_flourish.preflourishconsent',
             subject_identifier=self.pre_flourish_subject_consent.subject_identifier,

--- a/pre_flourish/tests/test_reconsent.py
+++ b/pre_flourish/tests/test_reconsent.py
@@ -123,6 +123,7 @@ class Reconsent(TestCase):
             pf_caregiver_child_consent.version
         )
 
+    @tag('nc')
     def test_new_consent(self):
         """Test if new consent gets latest running consent version"""
         locator = mommy.make_recipe(
@@ -135,8 +136,9 @@ class Reconsent(TestCase):
 
         pre_flourish_subject_consent = mommy.make_recipe(
             'pre_flourish.preflourishconsent',
-            screening_identifier=caregiver_screening.screening_identifier,
-            version=str(pre_flourish_config.consent_version))
+            screening_identifier=caregiver_screening.screening_identifier, )
+
+        pre_flourish_subject_consent.save()
 
         self.assertEqual(
             PFConsentVersion.objects.filter(

--- a/pre_flourish/tests/test_reconsent.py
+++ b/pre_flourish/tests/test_reconsent.py
@@ -1,4 +1,5 @@
 from dateutil.relativedelta import relativedelta
+from django.apps import apps as django_apps
 from django.test import tag, TestCase
 from edc_base import get_utcnow
 from edc_facility.import_holidays import import_holidays
@@ -7,6 +8,8 @@ from model_mommy import mommy
 from pre_flourish.models import PFConsentVersion
 from pre_flourish.models.appointment import Appointment
 
+pre_flourish_config = django_apps.get_app_config('pre_flourish')
+
 
 @tag('reconsent')
 class Reconsent(TestCase):
@@ -14,8 +17,7 @@ class Reconsent(TestCase):
         import_holidays()
         self.subject_identifier = '12345678'
         self.study_maternal_identifier = '89721'
-        self.options = {
-            'version': '1'}
+        self.options = {'version': '1'}
 
         self.locator = mommy.make_recipe(
             'pre_flourish.caregiverlocator',
@@ -55,6 +57,97 @@ class Reconsent(TestCase):
             visit_code='0200',
             subject_identifier=self.pf_caregiver_child_consent.subject_identifier)
 
+    def test_creates_consent_version_obj(self):
+        """Test consent version object is created"""
+        locator = mommy.make_recipe(
+            'pre_flourish.caregiverlocator',
+            study_maternal_identifier='211111', )
+
+        caregiver_screening = mommy.make_recipe(
+            'pre_flourish.preflourishsubjectscreening',
+            study_maternal_identifier='211111')
+
+        pre_flourish_subject_consent = mommy.make_recipe(
+            'pre_flourish.preflourishconsent',
+            screening_identifier=caregiver_screening.screening_identifier,
+            version='1')
+
+        self.assertEqual(
+            PFConsentVersion.objects.filter(
+                screening_identifier=caregiver_screening.screening_identifier).count(), 1)
+
+        self.assertEqual(
+            PFConsentVersion.objects.get(
+                screening_identifier=caregiver_screening.screening_identifier).version,
+            pre_flourish_subject_consent.version
+        )
+
+    @tag('ucvo')
+    def test_updates_consent_version_obj(self):
+        """Test if consent version object is updated correctly with child consent
+        version"""
+        locator = mommy.make_recipe(
+            'pre_flourish.caregiverlocator',
+            study_maternal_identifier='211111', )
+
+        caregiver_screening = mommy.make_recipe(
+            'pre_flourish.preflourishsubjectscreening',
+            study_maternal_identifier='211111')
+
+        pre_flourish_subject_consent = mommy.make_recipe(
+            'pre_flourish.preflourishconsent',
+            screening_identifier=caregiver_screening.screening_identifier,
+            version='1')
+
+        self.assertEqual(
+            PFConsentVersion.objects.filter(
+                screening_identifier=caregiver_screening.screening_identifier).count(), 1)
+
+        self.assertIsNone(
+            PFConsentVersion.objects.get(
+                screening_identifier=caregiver_screening.screening_identifier
+            ).child_version,
+        )
+
+        pf_caregiver_child_consent = mommy.make_recipe(
+            'pre_flourish.preflourishcaregiverchildconsent',
+            subject_consent=pre_flourish_subject_consent,
+            child_dob=get_utcnow() - relativedelta(years=11, months=5),
+            version='1'
+        )
+
+        self.assertEqual(
+            PFConsentVersion.objects.get(
+                screening_identifier=caregiver_screening.screening_identifier
+            ).child_version,
+            pf_caregiver_child_consent.version
+        )
+
+    def test_new_consent(self):
+        """Test if new consent gets latest running consent version"""
+        locator = mommy.make_recipe(
+            'pre_flourish.caregiverlocator',
+            study_maternal_identifier='211111', )
+
+        caregiver_screening = mommy.make_recipe(
+            'pre_flourish.preflourishsubjectscreening',
+            study_maternal_identifier='211111')
+
+        pre_flourish_subject_consent = mommy.make_recipe(
+            'pre_flourish.preflourishconsent',
+            screening_identifier=caregiver_screening.screening_identifier,
+            version=str(pre_flourish_config.consent_version))
+
+        self.assertEqual(
+            PFConsentVersion.objects.filter(
+                screening_identifier=caregiver_screening.screening_identifier).count(), 1)
+
+        self.assertEqual(
+            PFConsentVersion.objects.get(
+                screening_identifier=caregiver_screening.screening_identifier).version,
+            str(pre_flourish_config.consent_version)
+        )
+
     def test_reconsent(self):
         consent_version_obj = PFConsentVersion.objects.get(
             screening_identifier=self.caregiver_screening.screening_identifier)
@@ -78,3 +171,25 @@ class Reconsent(TestCase):
         self.assertEqual(version_4.version, '4')
         self.assertEqual(child_version_4.version, '4')
 
+    def test_reconsent_latest(self):
+        consent_version_obj = PFConsentVersion.objects.get(
+            screening_identifier=self.caregiver_screening.screening_identifier)
+        consent_version_obj.version = '4.1'
+        consent_version_obj.child_version = '4'
+        consent_version_obj.save()
+        version_4 = mommy.make_recipe(
+            'pre_flourish.preflourishconsent',
+            subject_identifier=self.pre_flourish_subject_consent.subject_identifier,
+            screening_identifier=self.pre_flourish_subject_consent.screening_identifier,
+            version=str(pre_flourish_config.consent_version)
+        )
+
+        child_version_4 = mommy.make_recipe(
+            'pre_flourish.preflourishcaregiverchildconsent',
+            subject_consent=version_4,
+            child_dob=get_utcnow() - relativedelta(years=11, months=5),
+            version=str(pre_flourish_config.child_consent_version)
+        )
+
+        self.assertEqual(version_4.version, '4.1')
+        self.assertEqual(child_version_4.version, '4')


### PR DESCRIPTION
This commit updates the handling of consent versions in the pre-flourish models. Updates include editing the create_consent_version function to allow for an optional child version parameter, changing the default version from the current app configuration to '1' if a ConsentVersion object does not yet exist, and adding tests to verify this functionality. Updates also cover version property to pull from ConsentVersion model or default to '1' if not defined just before the save action. Transferred child consent version operations to the child signals.py from caregiver signals.py. Also, the consent version has been updated to 4.1.