### PR TITLE
(refactor): Update read-only field conditions in admin modules

### DIFF
--- a/pre_flourish/admin/caregiver/pre_flourish_consent_admin.py
+++ b/pre_flourish/admin/caregiver/pre_flourish_consent_admin.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 from django.apps import apps as django_apps
 from django.contrib import admin
+from django.db.models import Q
 from django.urls.base import reverse
 from django.urls.exceptions import NoReverseMatch
 from django_revision.modeladmin_mixin import ModelAdminRevisionMixin
@@ -211,5 +212,11 @@ class PreFlourishConsentAdmin(ModelAdminBasicMixin, ModelAdminMixin, ConsentMixi
         return multiple_births
 
     def get_readonly_fields(self, request, obj=None):
+        if obj:
+            existing_objects = PreFlourishConsent.objects.filter(~Q(id=obj.id))
+
+            if existing_objects.exists():
+                return [f.name for f in self.model._meta.fields if
+                        f.name not in audit_fields]
         return (super().get_readonly_fields(request, obj=obj) +
                 audit_fields)

--- a/pre_flourish/admin/caregiver/pre_flourish_consent_admin.py
+++ b/pre_flourish/admin/caregiver/pre_flourish_consent_admin.py
@@ -213,10 +213,6 @@ class PreFlourishConsentAdmin(ModelAdminBasicMixin, ModelAdminMixin, ConsentMixi
 
     def get_readonly_fields(self, request, obj=None):
         if obj:
-            existing_objects = PreFlourishConsent.objects.filter(~Q(id=obj.id))
-
-            if existing_objects.exists():
-                return [f.name for f in self.model._meta.fields if
-                        f.name not in audit_fields]
+            return [f.name for f in self.model._meta.fields]
         return (super().get_readonly_fields(request, obj=obj) +
                 audit_fields)

--- a/pre_flourish/admin/child/pre_flourish_child_consent_admin.py
+++ b/pre_flourish/admin/child/pre_flourish_child_consent_admin.py
@@ -2,7 +2,7 @@ from functools import partialmethod
 
 from django.apps import apps as django_apps
 from django.contrib import admin
-from django.db.models import OuterRef, Subquery
+from django.db.models import OuterRef, Q, Subquery
 from edc_model_admin import ModelAdminFormAutoNumberMixin, StackedInlineMixin
 
 from flourish_caregiver.admin import ConsentMixin
@@ -17,7 +17,6 @@ class PreFlourishCaregiverChildConsentInline(StackedInlineMixin,
                                              ChildConsentMixin,
                                              ConsentMixin,
                                              admin.StackedInline):
-
     caregiver_consent_cls = django_apps.get_model('pre_flourish.preflourishconsent')
 
     consent_cls = django_apps.get_model(
@@ -116,7 +115,6 @@ class PreFlourishCaregiverChildConsentInline(StackedInlineMixin,
 @admin.register(PreFlourishCaregiverChildConsent, site=pre_flourish_admin)
 class PreFlourishCaregiverChildConsentAdmin(ModelAdminMixin, ChildConsentMixin,
                                             admin.ModelAdmin):
-
     list_display = ('subject_identifier',
                     'verified_by',
                     'is_verified',
@@ -140,3 +138,12 @@ class PreFlourishCaregiverChildConsentAdmin(ModelAdminMixin, ChildConsentMixin,
 
     search_fields = ['subject_identifier',
                      'subject_consent__subject_identifier', ]
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:
+            existing_objects = PreFlourishCaregiverChildConsent.objects.filter(~Q(id=obj.id))
+
+            if existing_objects.exists():  # if there are other objects
+                return [f.name for f in self.model._meta.fields]
+
+        return super().get_readonly_fields(request, obj)

--- a/pre_flourish/admin/child/pre_flourish_child_consent_admin.py
+++ b/pre_flourish/admin/child/pre_flourish_child_consent_admin.py
@@ -141,9 +141,6 @@ class PreFlourishCaregiverChildConsentAdmin(ModelAdminMixin, ChildConsentMixin,
 
     def get_readonly_fields(self, request, obj=None):
         if obj:
-            existing_objects = PreFlourishCaregiverChildConsent.objects.filter(~Q(id=obj.id))
-
-            if existing_objects.exists():  # if there are other objects
-                return [f.name for f in self.model._meta.fields]
+            return [f.name for f in self.model._meta.fields]
 
         return super().get_readonly_fields(request, obj)

--- a/pre_flourish/templates/pre_flourish/buttons/consent_version_button.html
+++ b/pre_flourish/templates/pre_flourish/buttons/consent_version_button.html
@@ -1,12 +1,6 @@
 <a id="flourishconsentversion_add_{{ screening_identifier }}"
    title="{{ title }}"
-
-        {% if is_latest_consent_version %}
-   class="btn btn-success btn-sm" data-toggle="tooltip"  data-placement="right"
+   class="btn btn-success btn-sm" data-toggle="tooltip" data-placement="right"
    href="{{ add_consent_version_href }}">
-        {% else %}
-            class="btn btn-warning btn-sm" data-toggle="tooltip" data-placement="right"
-            href="{{ add_consent_version_href }}">
-        {% endif %}
-Consent Version
+    Consent Version
 </a>


### PR DESCRIPTION
The admin modules `pre_flourish_child_consent_admin.py` and `pre_flourish_consent_admin.py` have been updated. The `get_readonly_fields` function in both modules now includes conditions to check if objects exist and then sets all fields as read-only. These changes prevent fields from being edited after object creation. This measure ensures data integrity by inhibiting unwanted modifications.